### PR TITLE
INT-2830: Update examples for TinyMCE swing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*     @tiny-james @jscasca @tinydylan
+*     @tiny-james @jscasca

--- a/build.xml
+++ b/build.xml
@@ -2,6 +2,11 @@
   <description>
     Build and run code samples for "TinyMCE for Swing".
   </description>
+  <!-- Configure the cloud and external examples -->
+  <property name="tinyCloudApiKey" value="no-api-key"/>
+  <property name="tinyCloudChannel" value="6"/>
+  <property name="tinymceUrl" value="http://localhost/web/tinymce/tinymce.min.js"/>
+
   <!-- set global properties for this build -->
   <property name="lib" location="lib"/>
   <property name="src" location="src"/>
@@ -41,7 +46,10 @@
   </target>
 
   <target name="example-basic-cloud" depends="compile" description="Run the basic cloud example (requires setting API key).">
-    <java classpathref="classpath.all" classname="cloud.tiny.tinyinswing.examples.basic.cloud.CloudExample" fork="true" failonerror="true" />
+    <java classpathref="classpath.all" classname="cloud.tiny.tinyinswing.examples.basic.cloud.CloudExample" fork="true" failonerror="true" >
+      <env key="CLOUD_API_KEY" value="${tinyCloudApiKey}"/>
+      <env key="CLOUD_CHANNEL" value="${tinyCloudChannel}"/>
+    </java>
   </target>
 
   <target name="example-basic-embedded" depends="compile" description="Run the basic embedded example.">
@@ -49,7 +57,9 @@
   </target>
 
   <target name="example-basic-external" depends="compile" description="Run the basic external example (requires hosting TinyMCE).">
-    <java classpathref="classpath.all" classname="cloud.tiny.tinyinswing.examples.basic.external.ExternalExample" fork="true" failonerror="true" />
+    <java classpathref="classpath.all" classname="cloud.tiny.tinyinswing.examples.basic.external.ExternalExample" fork="true" failonerror="true" >
+      <env key="TINYMCE_URL" value="${tinymceUrl}"/>
+    </java>
   </target>
 
   <target name="example-config-js" depends="compile" description="Run the example of configuring TinyMCE from a Javascript file.">
@@ -67,13 +77,17 @@
   <target name="example-dialog" depends="compile" description="Run the example of accessing the editor from a dialog.">
     <java classpathref="classpath.all" classname="cloud.tiny.tinyinswing.examples.dialog.DialogExample" fork="true" failonerror="true" />
   </target>
-
-  <target name="example-events-basic-js-to-java" depends="compile" description="Run the basic example of sending events to java.">
-    <java classpathref="classpath.all" classname="cloud.tiny.tinyinswing.examples.events.basicjstojava.BasicJsToJavaEventsExample" fork="true" failonerror="true" />
+  
+  <target name="example-drag-n-drop" depends="compile" description="Run the example of drag and drop to TinyMCE.">
+    <java classpathref="classpath.all" classname="cloud.tiny.tinyinswing.examples.dragndrop.DragNDropExample" fork="true" failonerror="true" />
   </target>
 
   <target name="example-events-basic-java-to-js" depends="compile" description="Run the basic example of sending events to js.">
     <java classpathref="classpath.all" classname="cloud.tiny.tinyinswing.examples.events.basicjavatojs.BasicJavaToJsEventsExample" fork="true" failonerror="true" />
+  </target>
+
+  <target name="example-events-basic-js-to-java" depends="compile" description="Run the basic example of sending events to java.">
+    <java classpathref="classpath.all" classname="cloud.tiny.tinyinswing.examples.events.basicjstojava.BasicJsToJavaEventsExample" fork="true" failonerror="true" />
   </target>
 
   <target name="example-events-create-link" depends="compile" description="Run the events example of combining Js and Java UI.">
@@ -93,10 +107,8 @@
   <target name="example-multiple-editors" depends="compile" description="Run the example of multiple editors.">
     <java classpathref="classpath.all" classname="cloud.tiny.tinyinswing.examples.multipleeditors.MultipleEditorsExample" fork="true" failonerror="true" />
   </target>
+
   <target name="example-text-range" depends="compile" description="Run the example of text range.">
     <java classpathref="classpath.all" classname="cloud.tiny.tinyinswing.examples.textrange.TextRangeExample" fork="true" failonerror="true" />
-  </target>
-  <target name="example-drag-n-drop" depends="compile" description="Run the example of drag and drop to TinyMCE.">
-    <java classpathref="classpath.all" classname="cloud.tiny.tinyinswing.examples.dragndrop.DragNDropExample" fork="true" failonerror="true" />
   </target>
 </project>

--- a/src/cloud/tiny/tinyinswing/examples/basic/cloud/CloudExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/basic/cloud/CloudExample.java
@@ -7,32 +7,47 @@ import cloud.tiny.tinyinswing.shared.Utils;
 
 import javax.swing.*;
 import java.awt.*;
-import java.util.Arrays;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 public final class CloudExample {
 
+  // This API key can be set in the Ant build.xml or you can set it here directly
+  public static String CLOUD_API_KEY = Optional.ofNullable(System.getenv("CLOUD_API_KEY"))
+      .orElse("no-api-key");
+  // This cloud channel can be set in the Ant build.xml or you can set it here directly
+  public static String CLOUD_CHANNEL = Optional.ofNullable(System.getenv("CLOUD_CHANNEL"))
+      .orElse("6");
+
   private CloudExample() {}
 
-  public static void main(final String[] args) throws ExecutionException, InterruptedException {
-    // Create a new cloud configuration by adding your API key
-    final Config cloudBased = Config.cloud("<my_api_key>", "5-testing");
-    // Create a new editor with the default cloud configuration
-    final TinyMCE editor = TinyMCE.futureEditor(cloudBased).get();
-    // Set the editor content
-    editor.setHtml(Utils.welcomeText);
-    // Create a button to get the content of the editor
-    final JButton printToConsole = new JButton("Print to console");
-    printToConsole.addActionListener(e -> System.out.println(editor.getHtml()));
-    // Add the editor and button to the JFrame
-    final JFrame frame = new JFrame();
-    frame.add(editor.component(), BorderLayout.CENTER);
-    frame.add(printToConsole, BorderLayout.SOUTH);
-    frame.pack();
-    frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-    // ensure the editor resources are cleaned up when the window is closed
-    TinyMCE.shutdownOnClose(frame);
-    // display the editor
-    frame.setVisible(true);
+  private static void createAndShowGUI() {
+    try {
+      // Create a new cloud configuration
+      final Config cloudBased = Config.cloud(CLOUD_API_KEY, CLOUD_CHANNEL);
+      // Create a new editor with the default cloud configuration
+      final TinyMCE editor = TinyMCE.futureEditor(cloudBased).get();
+      // Set the editor content
+      editor.setHtml(Utils.sampleText);
+      // Create a button to get the content of the editor
+      final JButton printToConsole = new JButton("Print to console");
+      printToConsole.addActionListener(e -> System.out.println(editor.getHtml()));
+      // Add the editor and button to the JFrame
+      final JFrame frame = new JFrame();
+      frame.add(editor.component(), BorderLayout.CENTER);
+      frame.add(printToConsole, BorderLayout.SOUTH);
+      frame.pack();
+      frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+      // ensure the editor resources are cleaned up when the window is closed
+      TinyMCE.shutdownOnClose(frame);
+      // display the editor
+      frame.setVisible(true);
+    } catch (ExecutionException | InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public static void main(final String[] args) {
+    SwingUtilities.invokeLater(CloudExample::createAndShowGUI);
   }
 }

--- a/src/cloud/tiny/tinyinswing/examples/basic/embedded/EmbeddedExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/basic/embedded/EmbeddedExample.java
@@ -12,25 +12,33 @@ public class EmbeddedExample {
 
   private EmbeddedExample(){}
 
-  public static void main(final String[] args) throws ExecutionException, InterruptedException {
-    // Create a new embedded configuration
-    final Config embeddedBased = Config.embedded();
-    // Create a new editor with the default configuration
-    final TinyMCE editor = TinyMCE.futureEditor(embeddedBased).get();
-    // Set the editor content
-    editor.setHtml(Utils.welcomeText);
-    // Create a button to get the content of the editor
-    final JButton printToConsole = new JButton("Print to console");
-    printToConsole.addActionListener(e -> System.out.println(editor.getHtml()));
-    // Add the editor and button to the JFrame
-    final JFrame frame = new JFrame();
-    frame.add(editor.component(), BorderLayout.CENTER);
-    frame.add(printToConsole, BorderLayout.SOUTH);
-    frame.pack();
-    frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-    // ensure the editor resources are cleaned up when the window is closed
-    TinyMCE.shutdownOnClose(frame);
-    // display the editor
-    frame.setVisible(true);
+  private static void createAndShowGUI() {
+    try {
+      // Create a new embedded configuration
+      final Config embeddedBased = Config.embedded().putProperty("browser_spellcheck", true);
+      // Create a new editor with the default configuration
+      final TinyMCE editor = TinyMCE.futureEditor(embeddedBased).get();
+      // Set the editor content
+      editor.setHtml(Utils.sampleText);
+      // Create a button to get the content of the editor
+      final JButton printToConsole = new JButton("Print to console");
+      printToConsole.addActionListener(e -> System.out.println(editor.getHtml()));
+      // Add the editor and button to the JFrame
+      final JFrame frame = new JFrame();
+      frame.add(editor.component(), BorderLayout.CENTER);
+      frame.add(printToConsole, BorderLayout.SOUTH);
+      frame.pack();
+      frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+      // ensure the editor resources are cleaned up when the window is closed
+      TinyMCE.shutdownOnClose(frame);
+      // display the editor
+      frame.setVisible(true);
+    } catch (ExecutionException | InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public static void main(final String[] args) {
+    SwingUtilities.invokeLater(EmbeddedExample::createAndShowGUI);
   }
 }

--- a/src/cloud/tiny/tinyinswing/examples/basic/external/ExternalExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/basic/external/ExternalExample.java
@@ -6,32 +6,44 @@ import cloud.tiny.tinyinswing.shared.Utils;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 public class ExternalExample {
 
+  // This URL can be set in the Ant build.xml or you can set it here directly
+  public static String TINYMCE_URL = Optional.ofNullable(System.getenv("TINYMCE_URL"))
+      .orElse("http://localhost/web/tinymce/tinymce.min.js");
+
   private ExternalExample(){}
 
-  public static void main(final String[] args) throws ExecutionException, InterruptedException {
-    // Create a new external configuration by adding the url of your custom TinyMCE editor (tinymce.min.js)
-    // TODO: Replace the URL with the URL of your tinyMCE library
-    final Config externalBased = Config.external("http://localhost/web/tinymce/tinymce.min.js");
-    // Create a new editor with the default configuration
-    final TinyMCE editor = TinyMCE.futureEditor(externalBased).get();
-    // Set the editor content
-    editor.setHtml(Utils.welcomeText);
-    // Create a button to get the content of the editor
-    final JButton printToConsole = new JButton("Print to console");
-    printToConsole.addActionListener(e -> System.out.println(editor.getHtml()));
-    // Add the editor and button to the JFrame
-    final JFrame frame = new JFrame();
-    frame.add(editor.component(), BorderLayout.CENTER);
-    frame.add(printToConsole, BorderLayout.SOUTH);
-    frame.pack();
-    frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-    // ensure the editor resources are cleaned up when the window is closed
-    TinyMCE.shutdownOnClose(frame);
-    // display the editor
-    frame.setVisible(true);
+  private static void createAndShowGUI() {
+    try {
+      // Create a new external configuration by adding the url of your custom TinyMCE editor (tinymce.min.js)
+      final Config externalBased = Config.external(TINYMCE_URL);
+      // Create a new editor with the default configuration
+      final TinyMCE editor = TinyMCE.futureEditor(externalBased).get();
+      // Set the editor content
+      editor.setHtml(Utils.sampleText);
+      // Create a button to get the content of the editor
+      final JButton printToConsole = new JButton("Print to console");
+      printToConsole.addActionListener(e -> System.out.println(editor.getHtml()));
+      // Add the editor and button to the JFrame
+      final JFrame frame = new JFrame();
+      frame.add(editor.component(), BorderLayout.CENTER);
+      frame.add(printToConsole, BorderLayout.SOUTH);
+      frame.pack();
+      frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+      // ensure the editor resources are cleaned up when the window is closed
+      TinyMCE.shutdownOnClose(frame);
+      // display the editor
+      frame.setVisible(true);
+    } catch (ExecutionException | InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public static void main(final String[] args) {
+    SwingUtilities.invokeLater(ExternalExample::createAndShowGUI);
   }
 }

--- a/src/cloud/tiny/tinyinswing/examples/configuration/javascript/JsConfigurationExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/configuration/javascript/JsConfigurationExample.java
@@ -15,25 +15,34 @@ public class JsConfigurationExample {
 
   private JsConfigurationExample() {}
 
-  public static void main(final String[] args) throws ExecutionException, InterruptedException {
-    // Create a new embedded configuration and load TinyMCE's settings from config.js
-    final Config config = Config.embedded().setInitConf(JsConfigurationExample.class, "config.js");
-    // Create a new editor with the configuration
-    final TinyMCE editor = TinyMCE.futureEditor(config).get();
-    // Set the editor content
-    editor.setHtml(Utils.welcomeText);
-    // Create a button to get the content of the editor
-    final JButton printToConsole = new JButton("Print to console");
-    printToConsole.addActionListener(e -> System.out.println(editor.getHtml()));
-    // Add the editor and button to the JFrame
-    final JFrame frame = new JFrame();
-    frame.add(editor.component(), BorderLayout.CENTER);
-    frame.add(printToConsole, BorderLayout.SOUTH);
-    frame.pack();
-    frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-    // ensure the editor resources are cleaned up when the window is closed
-    TinyMCE.shutdownOnClose(frame);
-    // display the editor
-    frame.setVisible(true);
+  private static void createAndShowGUI() {
+    try {
+      // Create a new embedded configuration and load TinyMCE's settings from config.js
+      final Config config = Config.embedded()
+          .setInitConf(JsConfigurationExample.class, "config.js");
+      // Create a new editor with the configuration
+      final TinyMCE editor = TinyMCE.futureEditor(config).get();
+      // Set the editor content
+      editor.setHtml(Utils.sampleText);
+      // Create a button to get the content of the editor
+      final JButton printToConsole = new JButton("Print to console");
+      printToConsole.addActionListener(e -> System.out.println(editor.getHtml()));
+      // Add the editor and button to the JFrame
+      final JFrame frame = new JFrame();
+      frame.add(editor.component(), BorderLayout.CENTER);
+      frame.add(printToConsole, BorderLayout.SOUTH);
+      frame.pack();
+      frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+      // ensure the editor resources are cleaned up when the window is closed
+      TinyMCE.shutdownOnClose(frame);
+      // display the editor
+      frame.setVisible(true);
+    } catch (ExecutionException | InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public static void main(final String[] args) {
+    SwingUtilities.invokeLater(JsConfigurationExample::createAndShowGUI);
   }
 }

--- a/src/cloud/tiny/tinyinswing/examples/configuration/javascript/config.js
+++ b/src/cloud/tiny/tinyinswing/examples/configuration/javascript/config.js
@@ -2,14 +2,15 @@
   return {
     menubar: false,
     plugins: [
-      'advlist autolink lists link image charmap print preview anchor textcolor',
-      'searchreplace visualblocks code fullscreen',
-      'insertdatetime media table paste powerpaste code help wordcount'
+      'advlist', 'anchor', 'autolink', 'charmap', 'code', 'fullscreen', 'help',
+      'image', 'insertdatetime', 'link', 'lists', 'media', 'preview',
+      'searchreplace', 'table', 'visualblocks', 'wordcount'
     ],
-    toolbar: 'undo redo | formatselect | bold italic backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | removeformat | help',
+    toolbar: 'undo redo | blocks | bold italic backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | removeformat | help',
     content_css: [
       '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
       '//www.tiny.cloud/css/codepen.min.css'
-    ]
+    ],
+    skin: 'tinymce-5'
   };
 })()

--- a/src/cloud/tiny/tinyinswing/examples/configuration/javascript/config.js
+++ b/src/cloud/tiny/tinyinswing/examples/configuration/javascript/config.js
@@ -11,6 +11,5 @@
       '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
       '//www.tiny.cloud/css/codepen.min.css'
     ],
-    skin: 'tinymce-5'
   };
 })()

--- a/src/cloud/tiny/tinyinswing/examples/configuration/properties/PropertiesConfigurationExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/configuration/properties/PropertiesConfigurationExample.java
@@ -13,28 +13,37 @@ public final class PropertiesConfigurationExample {
 
   private PropertiesConfigurationExample(){}
 
-  public static void main(final String[] args) throws ExecutionException, InterruptedException {
-    // Create a new embedded configuration and set TinyMCE's settings
-    final Config config = Config.embedded()
-      .putProperty("menubar", "false")
-      .putProperty("plugins", "advlist autolink lists link image charmap print preview anchor textcolor searchreplace visualblocks code insertdatetime media table paste powerpaste code help wordcount")
-      .putProperty("toolbar", "undo redo | formatselect | bold italic backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | removeformat | help");
-    // Create a new editor with the configuration
-    final TinyMCE editor = TinyMCE.futureEditor(config).get();
-    // Set the editor content
-    editor.setHtml(Utils.welcomeText);
-    // Create a button to get the content of the editor
-    final JButton printToConsole = new JButton("Print to console");
-    printToConsole.addActionListener(e -> System.out.println(editor.getHtml()));
-    // Add the editor and button to the JFrame
-    final JFrame frame = new JFrame();
-    frame.add(editor.component(), BorderLayout.CENTER);
-    frame.add(printToConsole, BorderLayout.SOUTH);
-    frame.pack();
-    frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-    // ensure the editor resources are cleaned up when the window is closed
-    TinyMCE.shutdownOnClose(frame);
-    // display the editor
-    frame.setVisible(true);
+  private static void createAndShowGUI() {
+    try {
+      // Create a new embedded configuration and set TinyMCE's settings
+      final Config config = Config.embedded()
+        .addPlugins("advlist anchor autolink charmap code fullscreen help image insertdatetime link lists media preview searchreplace table visualblocks wordcount")
+        .putProperty("toolbar", "undo redo | blocks | bold italic backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | removeformat | help")
+        .putProperty("menubar", false)
+        .putProperty("skin", "tinymce-5");
+      // Create a new editor with the configuration
+      final TinyMCE editor = TinyMCE.futureEditor(config).get();
+      // Set the editor content
+      editor.setHtml(Utils.sampleText);
+      // Create a button to get the content of the editor
+      final JButton printToConsole = new JButton("Print to console");
+      printToConsole.addActionListener(e -> System.out.println(editor.getHtml()));
+      // Add the editor and button to the JFrame
+      final JFrame frame = new JFrame();
+      frame.add(editor.component(), BorderLayout.CENTER);
+      frame.add(printToConsole, BorderLayout.SOUTH);
+      frame.pack();
+      frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+      // ensure the editor resources are cleaned up when the window is closed
+      TinyMCE.shutdownOnClose(frame);
+      // display the editor
+      frame.setVisible(true);
+    } catch (ExecutionException | InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public static void main(final String[] args) {
+    SwingUtilities.invokeLater(PropertiesConfigurationExample::createAndShowGUI);
   }
 }

--- a/src/cloud/tiny/tinyinswing/examples/configuration/properties/PropertiesConfigurationExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/configuration/properties/PropertiesConfigurationExample.java
@@ -19,8 +19,7 @@ public final class PropertiesConfigurationExample {
       final Config config = Config.embedded()
         .addPlugins("advlist anchor autolink charmap code fullscreen help image insertdatetime link lists media preview searchreplace table visualblocks wordcount")
         .putProperty("toolbar", "undo redo | blocks | bold italic backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | removeformat | help")
-        .putProperty("menubar", false)
-        .putProperty("skin", "tinymce-5");
+        .putProperty("menubar", false);
       // Create a new editor with the configuration
       final TinyMCE editor = TinyMCE.futureEditor(config).get();
       // Set the editor content

--- a/src/cloud/tiny/tinyinswing/examples/customprotocol/CustomProtocolExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/customprotocol/CustomProtocolExample.java
@@ -17,45 +17,53 @@ public class CustomProtocolExample {
 
   private CustomProtocolExample() {}
 
-  public static void main(final String[] args) throws ExecutionException, InterruptedException {
-    // A custom protocol handlers will intercept all requests for a specific protocol `<protocol>://<path>`
-    // In this example we are adding a `localimg` protocol to handler urls like: `localimg://my_image.png`
-    TinyMCE.addProtocolHandler("localimg", new CustomProtocolHandler() {
-      // CustomProtocolHandlers use the onRequest method to take a customUrlRequest and return a CustomUrlResponse
-      @Override
-      public CustomURLResponse onRequest(CustomURLRequest customURLRequest) {
-        // The CustomURLRequest object contains the Url, method and headers of the request
-        // The CustomURLResponse object takes an array of bytes as the response content, an http status code (int), and, optionally, extra headers
-        final CustomURLResponse r;
-        if (customURLRequest.getUrl().endsWith(".png")) {
-          // `localImage` is a base64 encoded image string
-          String data = Utils.localImage.substring(Utils.localImage.indexOf(",") + 1);
-          r = new CustomURLResponse(Base64.getDecoder().decode(data), 200);
-        } else {
-          r = new CustomURLResponse("".getBytes(), 404);
+  private static void createAndShowGUI() {
+    try {
+      // A custom protocol handlers will intercept all requests for a specific protocol `<protocol>://<path>`
+      // In this example we are adding a `localimg` protocol to handler urls like: `localimg://my_image.png`
+      TinyMCE.addProtocolHandler("localimg", new CustomProtocolHandler() {
+        // CustomProtocolHandlers use the onRequest method to take a customUrlRequest and return a CustomUrlResponse
+        @Override
+        public CustomURLResponse onRequest(CustomURLRequest customURLRequest) {
+          // The CustomURLRequest object contains the Url, method and headers of the request
+          // The CustomURLResponse object takes an array of bytes as the response content, an http status code (int), and, optionally, extra headers
+          final CustomURLResponse r;
+          if (customURLRequest.getUrl().endsWith(".png")) {
+            // `localImage` is a base64 encoded image string
+            String data = Utils.localImage.substring(Utils.localImage.indexOf(",") + 1);
+            r = new CustomURLResponse(Base64.getDecoder().decode(data), 200);
+          } else {
+            r = new CustomURLResponse("".getBytes(), 404);
+          }
+          return r;
         }
-        return r;
-      }
-    });
-    // Create a new embedded configuration
-    final Config config = Config.embedded().addPlugin("link").addPlugin("print").addPlugin("powerpaste");
-    // Create a new editor with the default configuration
-    final TinyMCE editor = TinyMCE.futureEditor(config).get();
-    // Set the editor content. The `localimg` protocol will be handled by our custom protocol handler defined previously
-    editor.setHtml("<p><img src='localimg://my_image.png'></p>" +
-        "<p><img src='localimg://not_an_image.txt'></p>");
-    // Create a button to get the content of the editor
-    final JButton printToConsole = new JButton("Print to console");
-    printToConsole.addActionListener(e -> System.out.println(editor.getHtml()));
-    // Add the editor and button to the JFrame
-    final JFrame frame = new JFrame();
-    frame.add(editor.component(), BorderLayout.CENTER);
-    frame.add(printToConsole, BorderLayout.SOUTH);
-    frame.pack();
-    frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-    // ensure the editor resources are cleaned up when the window is closed
-    TinyMCE.shutdownOnClose(frame);
-    // display the editor
-    frame.setVisible(true);
+      });
+      // Create a new embedded configuration
+      final Config config = Config.embedded().addPlugin("link").putProperty("skin", "tinymce-5");
+      // Create a new editor with the default configuration
+      final TinyMCE editor = TinyMCE.futureEditor(config).get();
+      // Set the editor content. The `localimg` protocol will be handled by our custom protocol handler defined previously
+      editor.setHtml("<p><img src='localimg://my_image.png'></p>" +
+          "<p><img src='localimg://not_an_image.txt'></p>");
+      // Create a button to get the content of the editor
+      final JButton printToConsole = new JButton("Print to console");
+      printToConsole.addActionListener(e -> System.out.println(editor.getHtml()));
+      // Add the editor and button to the JFrame
+      final JFrame frame = new JFrame();
+      frame.add(editor.component(), BorderLayout.CENTER);
+      frame.add(printToConsole, BorderLayout.SOUTH);
+      frame.pack();
+      frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+      // ensure the editor resources are cleaned up when the window is closed
+      TinyMCE.shutdownOnClose(frame);
+      // display the editor
+      frame.setVisible(true);
+    } catch (ExecutionException | InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public static void main(final String[] args) {
+    SwingUtilities.invokeLater(CustomProtocolExample::createAndShowGUI);
   }
 }

--- a/src/cloud/tiny/tinyinswing/examples/customprotocol/CustomProtocolExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/customprotocol/CustomProtocolExample.java
@@ -39,7 +39,7 @@ public class CustomProtocolExample {
         }
       });
       // Create a new embedded configuration
-      final Config config = Config.embedded().addPlugin("link").putProperty("skin", "tinymce-5");
+      final Config config = Config.embedded().addPlugin("link");
       // Create a new editor with the default configuration
       final TinyMCE editor = TinyMCE.futureEditor(config).get();
       // Set the editor content. The `localimg` protocol will be handled by our custom protocol handler defined previously

--- a/src/cloud/tiny/tinyinswing/examples/dialog/DialogExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/dialog/DialogExample.java
@@ -48,11 +48,11 @@ public final class DialogExample {
   }
 
   private static void displayDialog(final JEditorPane pane, final JButton edit) {
-    final Config config = Config.embedded();
+    final Config config = Config.embedded().putProperty("skin", "tinymce-5");
     TinyMCE.futureEditor(config).thenAccept(editor -> openDialog(editor, pane, edit));
   }
 
-  public static void main(final String[] args) {
+  private static void createAndShowGUI() {
     final JEditorPane editable = new JEditorPane();
     editable.setContentType("text/html");
     editable.setText(Utils.sampleText);
@@ -75,5 +75,9 @@ public final class DialogExample {
     frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
     TinyMCE.shutdownOnClose(frame);
     frame.setVisible(true);
+  }
+
+  public static void main(final String[] args) {
+    SwingUtilities.invokeLater(DialogExample::createAndShowGUI);
   }
 }

--- a/src/cloud/tiny/tinyinswing/examples/dialog/DialogExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/dialog/DialogExample.java
@@ -48,7 +48,7 @@ public final class DialogExample {
   }
 
   private static void displayDialog(final JEditorPane pane, final JButton edit) {
-    final Config config = Config.embedded().putProperty("skin", "tinymce-5");
+    final Config config = Config.embedded();
     TinyMCE.futureEditor(config).thenAccept(editor -> openDialog(editor, pane, edit));
   }
 

--- a/src/cloud/tiny/tinyinswing/examples/dragndrop/DragNDropExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/dragndrop/DragNDropExample.java
@@ -49,44 +49,42 @@ public class DragNDropExample {
     }
   }
 
-  public static void setup() throws ExecutionException, InterruptedException {
-    // Create a new embedded configuration
-    final Config embeddedBased = Config.embedded().addPlugin("powerpaste").putProperty("powerpaste_html_import", "merge");
-    // Create a new editor with the default configuration
-    final TinyMCE editor = TinyMCE.futureEditor(embeddedBased).get();
-    // Set the editor content
-    editor.setHtml(Utils.lorumIpsum);
-    // Create a JTextArea which we can drag HTML from
-    final JTextArea source = new JTextArea(Utils.welcomeText, 50, 70);
-    source.setLineWrap(true);
-    source.setDragEnabled(true);
-    source.setTransferHandler(new HtmlTransferHandler());
-    final JScrollPane sourceScroll = new JScrollPane(source);
-    // Create a button to get the content of the editor
-    final JButton printToConsole = new JButton("Print to console");
-    printToConsole.addActionListener(e -> System.out.println(editor.getHtml()));
-    // Add the editor and button to the JFrame
-    final JFrame frame = new JFrame("Drag from a Java component into the editor");
-    frame.add(sourceScroll, BorderLayout.WEST);
-    frame.add(editor.component(), BorderLayout.EAST);
-    frame.add(printToConsole, BorderLayout.SOUTH);
-    frame.pack();
-    frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-    // ensure the editor resources are cleaned up when the window is closed
-    TinyMCE.shutdownOnClose(frame);
-    // display the editor
-    frame.setVisible(true);
-  }
-
-  public static void run() {
+  private static void createAndShowGUI() {
     try {
-      setup();
-    } catch (Exception e) {
+      // Create a new embedded configuration
+      final Config embeddedBased = Config.embedded()
+          .putProperty("powerpaste_html_import", "merge")
+          .putProperty("skin", "tinymce-5");
+      // Create a new editor with the default configuration
+      final TinyMCE editor = TinyMCE.futureEditor(embeddedBased).get();
+      // Set the editor content
+      editor.setHtml(Utils.sampleText);
+      // Create a JTextArea which we can drag HTML from
+      final JTextArea source = new JTextArea(Utils.sampleText, 50, 70);
+      source.setLineWrap(true);
+      source.setDragEnabled(true);
+      source.setTransferHandler(new HtmlTransferHandler());
+      final JScrollPane sourceScroll = new JScrollPane(source);
+      // Create a button to get the content of the editor
+      final JButton printToConsole = new JButton("Print to console");
+      printToConsole.addActionListener(e -> System.out.println(editor.getHtml()));
+      // Add the editor and button to the JFrame
+      final JFrame frame = new JFrame("Drag from a Java component into the editor");
+      frame.add(sourceScroll, BorderLayout.WEST);
+      frame.add(editor.component(), BorderLayout.EAST);
+      frame.add(printToConsole, BorderLayout.SOUTH);
+      frame.pack();
+      frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+      // ensure the editor resources are cleaned up when the window is closed
+      TinyMCE.shutdownOnClose(frame);
+      // display the editor
+      frame.setVisible(true);
+    } catch (ExecutionException | InterruptedException e) {
       e.printStackTrace();
     }
   }
 
   public static void main(String[] args) {
-    SwingUtilities.invokeLater(DragNDropExample::run);
+    SwingUtilities.invokeLater(DragNDropExample::createAndShowGUI);
   }
 }

--- a/src/cloud/tiny/tinyinswing/examples/dragndrop/DragNDropExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/dragndrop/DragNDropExample.java
@@ -53,8 +53,7 @@ public class DragNDropExample {
     try {
       // Create a new embedded configuration
       final Config embeddedBased = Config.embedded()
-          .putProperty("powerpaste_html_import", "merge")
-          .putProperty("skin", "tinymce-5");
+          .putProperty("powerpaste_html_import", "merge");
       // Create a new editor with the default configuration
       final TinyMCE editor = TinyMCE.futureEditor(embeddedBased).get();
       // Set the editor content

--- a/src/cloud/tiny/tinyinswing/examples/events/basicjavatojs/BasicJavaToJsEventsExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/events/basicjavatojs/BasicJavaToJsEventsExample.java
@@ -15,68 +15,76 @@ public class BasicJavaToJsEventsExample {
 
   private BasicJavaToJsEventsExample() {}
 
-  public static void main(String args[]) throws InterruptedException, ExecutionException {
-    // create the editor using the javascript config.js and a event listener
-    final Config config = Config.embedded()
-        .setInitConf(BasicJavaToJsEventsExample.class, "config.js");
-    // create the editor
-    final TinyMCE editor = TinyMCE.futureEditor(config).get();
-    // Set the editor content
-    editor.setHtml("");
-    // create a text area to report when we fire events in java
-    final JTextArea eventLog = new JTextArea(10, 40);
-    eventLog.setEditable(false);
-    eventLog.setLineWrap(true);
-    eventLog.setText("Events fired\n");
-    // create a panel of buttons for firing events
-    final Random random = new Random();
-    final JPanel buttons = new JPanel(new FlowLayout());
-    final JButton fireStringEvent = new JButton("Fire String Event");
-    fireStringEvent.addActionListener(evt -> {
-      final String value = String.format("%016x", random.nextLong());
-      eventLog.append("• Firing string-type event: " + value + "\n");
-      editor.fire("my-string-event", Codecs.stringCodec, value);
-    });
-    buttons.add(fireStringEvent);
-    final JButton fireDoubleEvent = new JButton("Fire Double Event");
-    fireDoubleEvent.addActionListener(evt -> {
-      final double value = random.nextDouble();
-      eventLog.append("• Firing double-type event: " + value + "\n");
-      editor.fire("my-double-event", Codecs.doubleCodec, value);
-    });
-    buttons.add(fireDoubleEvent);
-    final JButton fireBooleanEvent = new JButton("Fire Boolean Event");
-    fireBooleanEvent.addActionListener(evt -> {
-      final boolean value = random.nextBoolean();
-      eventLog.append("• Firing boolean-type event: " + value + "\n");
-      editor.fire("my-boolean-event", Codecs.booleanCodec, value);
-    });
-    buttons.add(fireBooleanEvent);
-    final JButton fireIntegerEvent = new JButton("Fire Integer Event");
-    fireIntegerEvent.addActionListener(evt -> {
-      final int value = random.nextInt();
-      eventLog.append("• Firing integer-type event: " + value + "\n");
-      editor.fire("my-integer-event", Codecs.integerCodec, value);
-    });
-    buttons.add(fireIntegerEvent);
-    final JButton fireLongEvent = new JButton("Fire Long Event");
-    fireLongEvent.addActionListener(evt -> {
-      // Javascript can't support the complete range of long in Java as the 
-      // value must be storable in a floating point number without loss in precision.
-      // The maximum supported value is 2^53-1 (9007199254740991)
-      final long value = (random.nextBoolean() ? -1l : 1l) * (long)Math.floor(random.nextDouble() * Math.pow(2.0, 53.0));
-      eventLog.append("• Firing long-type event: " + value + "\n");
-      editor.fire("my-long-event", Codecs.longCodec, value);
-    });
-    buttons.add(fireLongEvent);
-    // display the editor with the event buttons and messages panel
-    final JFrame frame = new JFrame("Java to Javascript Events Example");
-    frame.add(buttons, BorderLayout.NORTH);
-    frame.add(editor.component(), BorderLayout.CENTER);
-    frame.add(new JScrollPane(eventLog), BorderLayout.SOUTH);
-    frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-    TinyMCE.shutdownOnClose(frame);
-    frame.pack();
-    frame.setVisible(true);
+  private static void createAndShowGUI() {
+    try {
+      // create the editor using the javascript config.js and a event listener
+      final Config config = Config.embedded()
+          .setInitConf(BasicJavaToJsEventsExample.class, "config.js");
+      // create the editor
+      final TinyMCE editor = TinyMCE.futureEditor(config).get();
+      // Set the editor content
+      editor.setHtml("");
+      // create a text area to report when we fire events in java
+      final JTextArea eventLog = new JTextArea(10, 40);
+      eventLog.setEditable(false);
+      eventLog.setLineWrap(true);
+      eventLog.setText("Events fired\n");
+      // create a panel of buttons for firing events
+      final Random random = new Random();
+      final JPanel buttons = new JPanel(new FlowLayout());
+      final JButton fireStringEvent = new JButton("Fire String Event");
+      fireStringEvent.addActionListener(evt -> {
+        final String value = String.format("%016x", random.nextLong());
+        eventLog.append("• Firing string-type event: " + value + "\n");
+        editor.fire("my-string-event", Codecs.stringCodec, value);
+      });
+      buttons.add(fireStringEvent);
+      final JButton fireDoubleEvent = new JButton("Fire Double Event");
+      fireDoubleEvent.addActionListener(evt -> {
+        final double value = random.nextDouble();
+        eventLog.append("• Firing double-type event: " + value + "\n");
+        editor.fire("my-double-event", Codecs.doubleCodec, value);
+      });
+      buttons.add(fireDoubleEvent);
+      final JButton fireBooleanEvent = new JButton("Fire Boolean Event");
+      fireBooleanEvent.addActionListener(evt -> {
+        final boolean value = random.nextBoolean();
+        eventLog.append("• Firing boolean-type event: " + value + "\n");
+        editor.fire("my-boolean-event", Codecs.booleanCodec, value);
+      });
+      buttons.add(fireBooleanEvent);
+      final JButton fireIntegerEvent = new JButton("Fire Integer Event");
+      fireIntegerEvent.addActionListener(evt -> {
+        final int value = random.nextInt();
+        eventLog.append("• Firing integer-type event: " + value + "\n");
+        editor.fire("my-integer-event", Codecs.integerCodec, value);
+      });
+      buttons.add(fireIntegerEvent);
+      final JButton fireLongEvent = new JButton("Fire Long Event");
+      fireLongEvent.addActionListener(evt -> {
+        // Javascript can't support the complete range of long in Java as the 
+        // value must be storable in a floating point number without loss in precision.
+        // The maximum supported value is 2^53-1 (9007199254740991)
+        final long value = (random.nextBoolean() ? -1l : 1l) * (long)Math.floor(random.nextDouble() * Math.pow(2.0, 53.0));
+        eventLog.append("• Firing long-type event: " + value + "\n");
+        editor.fire("my-long-event", Codecs.longCodec, value);
+      });
+      buttons.add(fireLongEvent);
+      // display the editor with the event buttons and messages panel
+      final JFrame frame = new JFrame("Java to Javascript Events Example");
+      frame.add(buttons, BorderLayout.NORTH);
+      frame.add(editor.component(), BorderLayout.CENTER);
+      frame.add(new JScrollPane(eventLog), BorderLayout.SOUTH);
+      frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+      TinyMCE.shutdownOnClose(frame);
+      frame.pack();
+      frame.setVisible(true);
+    } catch (ExecutionException | InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public static void main(String args[]) {
+    SwingUtilities.invokeLater(BasicJavaToJsEventsExample::createAndShowGUI);
   }
 }

--- a/src/cloud/tiny/tinyinswing/examples/events/basicjavatojs/config.js
+++ b/src/cloud/tiny/tinyinswing/examples/events/basicjavatojs/config.js
@@ -1,8 +1,9 @@
 (function() {
   return {
     plugins: 'code',
-    toolbar: 'undo redo | formatselect | bold italic backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | removeformat | help',
-    // On setup define our buttons to fire events based on basic types
+    toolbar: 'undo redo | blocks | bold italic backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | removeformat | help',
+    skin: 'tinymce-5',
+    // On setup define our listeners to record events based on basic types
     setup(editor) {
       editor.on('my-string-event', (evt) => {
         // we show a message in the editor every time we receive the event

--- a/src/cloud/tiny/tinyinswing/examples/events/basicjavatojs/config.js
+++ b/src/cloud/tiny/tinyinswing/examples/events/basicjavatojs/config.js
@@ -2,7 +2,6 @@
   return {
     plugins: 'code',
     toolbar: 'undo redo | blocks | bold italic backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | removeformat | help',
-    skin: 'tinymce-5',
     // On setup define our listeners to record events based on basic types
     setup(editor) {
       editor.on('my-string-event', (evt) => {

--- a/src/cloud/tiny/tinyinswing/examples/events/basicjstojava/BasicJsToJavaEventsExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/events/basicjstojava/BasicJsToJavaEventsExample.java
@@ -13,42 +13,50 @@ public class BasicJsToJavaEventsExample {
 
   private BasicJsToJavaEventsExample() {}
 
-  public static void main(String args[]) throws InterruptedException, ExecutionException {
-    // create the editor using the javascript config.js and a event listener
-    final Config config = Config.embedded()
-        .setInitConf(BasicJsToJavaEventsExample.class, "config.js");
-    // create the editor
-    final TinyMCE editor = TinyMCE.futureEditor(config).get();
-    // Set the editor content
-    editor.setHtml("");
-    // create a text area to report when we receive events in Java
-    final JTextArea eventLog = new JTextArea(10, 40);
-    eventLog.setEditable(false);
-    eventLog.setLineWrap(true);
-    eventLog.setText("Events Received\n");
-    // display the editor with the event messages panel
-    final JFrame frame = new JFrame("Javascript to Java Events Example");
-    frame.add(editor.component(), BorderLayout.CENTER);
-    frame.add(new JScrollPane(eventLog), BorderLayout.SOUTH);
-    frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-    TinyMCE.shutdownOnClose(frame);
-    frame.pack();
-    frame.setVisible(true);
-    // add some event listeners
-    editor.on("my-string-event", Codecs.stringCodec, evt -> {
-      eventLog.append("• Received my-string-event: \"" + evt.data + "\"\n");
-    });
-    editor.on("my-double-event", Codecs.doubleCodec, evt -> {
-      eventLog.append("• Received my-double-event: " + evt.data + "\n");
-    });
-    editor.on("my-boolean-event", Codecs.booleanCodec, evt -> {
-      eventLog.append("• Received my-boolean-event: " + evt.data + "\n");
-    });
-    editor.on("my-integer-event", Codecs.integerCodec, evt -> {
-      eventLog.append("• Received my-integer-event: " + evt.data + "\n");
-    });
-    editor.on("my-long-event", Codecs.longCodec, evt -> {
-      eventLog.append("• Received my-long-event: " + evt.data + "\n");
-    });
+  private static void createAndShowGUI() {
+    try {
+      // create the editor using the javascript config.js and a event listener
+      final Config config = Config.embedded()
+          .setInitConf(BasicJsToJavaEventsExample.class, "config.js");
+      // create the editor
+      final TinyMCE editor = TinyMCE.futureEditor(config).get();
+      // Set the editor content
+      editor.setHtml("");
+      // create a text area to report when we receive events in Java
+      final JTextArea eventLog = new JTextArea(10, 40);
+      eventLog.setEditable(false);
+      eventLog.setLineWrap(true);
+      eventLog.setText("Events Received\n");
+      // display the editor with the event messages panel
+      final JFrame frame = new JFrame("Javascript to Java Events Example");
+      frame.add(editor.component(), BorderLayout.CENTER);
+      frame.add(new JScrollPane(eventLog), BorderLayout.SOUTH);
+      frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+      TinyMCE.shutdownOnClose(frame);
+      frame.pack();
+      frame.setVisible(true);
+      // add some event listeners
+      editor.on("my-string-event", Codecs.stringCodec, evt -> {
+        eventLog.append("• Received my-string-event: \"" + evt.data + "\"\n");
+      });
+      editor.on("my-double-event", Codecs.doubleCodec, evt -> {
+        eventLog.append("• Received my-double-event: " + evt.data + "\n");
+      });
+      editor.on("my-boolean-event", Codecs.booleanCodec, evt -> {
+        eventLog.append("• Received my-boolean-event: " + evt.data + "\n");
+      });
+      editor.on("my-integer-event", Codecs.integerCodec, evt -> {
+        eventLog.append("• Received my-integer-event: " + evt.data + "\n");
+      });
+      editor.on("my-long-event", Codecs.longCodec, evt -> {
+        eventLog.append("• Received my-long-event: " + evt.data + "\n");
+      });
+    } catch (ExecutionException | InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public static void main(String args[]) {
+    SwingUtilities.invokeLater(BasicJsToJavaEventsExample::createAndShowGUI);
   }
 }

--- a/src/cloud/tiny/tinyinswing/examples/events/basicjstojava/config.js
+++ b/src/cloud/tiny/tinyinswing/examples/events/basicjstojava/config.js
@@ -1,7 +1,6 @@
 (function() {
   return {
     plugins: 'code',
-    skin: 'tinymce-5',
     toolbar: 'StringEvent DoubleEvent BooleanEvent | IntegerEvent LongEvent',
     // On setup define our buttons to fire events based on basic types
     setup(editor) {

--- a/src/cloud/tiny/tinyinswing/examples/events/basicjstojava/config.js
+++ b/src/cloud/tiny/tinyinswing/examples/events/basicjstojava/config.js
@@ -1,6 +1,7 @@
 (function() {
   return {
     plugins: 'code',
+    skin: 'tinymce-5',
     toolbar: 'StringEvent DoubleEvent BooleanEvent | IntegerEvent LongEvent',
     // On setup define our buttons to fire events based on basic types
     setup(editor) {

--- a/src/cloud/tiny/tinyinswing/examples/events/createlink/CreateLinkEventsExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/events/createlink/CreateLinkEventsExample.java
@@ -11,33 +11,41 @@ public class CreateLinkEventsExample {
 
   private CreateLinkEventsExample() {}
 
-  public static void main(String args[]) throws InterruptedException, ExecutionException {
-    // create the editor using the javascript config.js and a event listener
-    final Config config = Config.embedded()
-        .setInitConf(CreateLinkEventsExample.class, "config.js")
-        // the event listener is declared for a class which has been annotated (look at JavaLink.java to see how)
-        .on(JavaLink.class, evt -> {
-          // the event has 4 properties:
-          // editor - a reference to tinymce if the editor has been initialized, otherwise empty.
-          // events - a interface that allows managing subscriptions to events and firing new events.
-          // name - the event name in lowercase.
-          // data - the event data which is an instance of the class used to subscribe to the event (ie JavaLink in this case).
-          final TinyMCE editor = evt.editor.get();
-          final JavaLink data = evt.data;
-          // when we receive the event we show a dialog to get a URL and insert that into the editor around the selected text
-          final String url = JOptionPane.showInputDialog(editor.component(), "Please input a URL.");
-          editor.insertHtml("<a href=\"" + url + "\">" + data.text + "</a>" );
-        });
-    // create the editor
-    final TinyMCE editor = TinyMCE.futureEditor(config).get();
-    // set the editor content
-    editor.setHtml(Utils.lorumIpsum);
-    // display the editor as the only component in a JFrame
-    final JFrame frame = new JFrame("Events Example");
-    frame.add(editor.component());
-    frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-    TinyMCE.shutdownOnClose(frame);
-    frame.pack();
-    frame.setVisible(true);
+  private static void createAndShowGUI() {
+    try {
+      // create the editor using the javascript config.js and a event listener
+      final Config config = Config.embedded()
+          .setInitConf(CreateLinkEventsExample.class, "config.js")
+          // the event listener is declared for a class which has been annotated (look at JavaLink.java to see how)
+          .on(JavaLink.class, evt -> {
+            // the event has 4 properties:
+            // editor - a reference to tinymce if the editor has been initialized, otherwise empty.
+            // events - a interface that allows managing subscriptions to events and firing new events.
+            // name - the event name in lowercase.
+            // data - the event data which is an instance of the class used to subscribe to the event (ie JavaLink in this case).
+            final TinyMCE editor = evt.editor.get();
+            final JavaLink data = evt.data;
+            // when we receive the event we show a dialog to get a URL and insert that into the editor around the selected text
+            final String url = JOptionPane.showInputDialog(editor.component(), "Please input a URL.");
+            editor.insertHtml("<a href=\"" + url + "\">" + data.text + "</a>" );
+          });
+      // create the editor
+      final TinyMCE editor = TinyMCE.futureEditor(config).get();
+      // set the editor content
+      editor.setHtml(Utils.sampleText);
+      // display the editor as the only component in a JFrame
+      final JFrame frame = new JFrame("Events Example");
+      frame.add(editor.component());
+      frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+      TinyMCE.shutdownOnClose(frame);
+      frame.pack();
+      frame.setVisible(true);
+    } catch (ExecutionException | InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public static void main(String args[]) {
+    SwingUtilities.invokeLater(CreateLinkEventsExample::createAndShowGUI);
   }
 }

--- a/src/cloud/tiny/tinyinswing/examples/events/createlink/config.js
+++ b/src/cloud/tiny/tinyinswing/examples/events/createlink/config.js
@@ -2,7 +2,6 @@
   return {
     plugins: 'advlist autolink lists link code',
     toolbar: 'undo redo code | insertJavaLink',
-    skin: 'tinymce-5',
     // On setup define our button to fire a JavaLink event
     setup(editor) {
       editor.ui.registry.addButton('insertJavaLink', {

--- a/src/cloud/tiny/tinyinswing/examples/events/createlink/config.js
+++ b/src/cloud/tiny/tinyinswing/examples/events/createlink/config.js
@@ -2,6 +2,7 @@
   return {
     plugins: 'advlist autolink lists link code',
     toolbar: 'undo redo code | insertJavaLink',
+    skin: 'tinymce-5',
     // On setup define our button to fire a JavaLink event
     setup(editor) {
       editor.ui.registry.addButton('insertJavaLink', {

--- a/src/cloud/tiny/tinyinswing/examples/image/protocolhandler/ImagesProtocolHandlerExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/image/protocolhandler/ImagesProtocolHandlerExample.java
@@ -12,68 +12,77 @@ import java.util.concurrent.ExecutionException;
 import javax.swing.*;
 
 
-
+/* WARNING: This example is outdated. Look at 'savinglocal' instead. */
 public class ImagesProtocolHandlerExample {
 
   private ImagesProtocolHandlerExample() {}
 
-  public static void main(final String[] args) throws ExecutionException, InterruptedException {
-    // Make a map to store images in base64
-    final HashMap<String, String> imageCache = new HashMap<>();
+  private static void createAndShowGUI() {
+    try {
+      // Make a map to store images in base64
+      final HashMap<String, String> imageCache = new HashMap<>();
 
-    /* Set up our custom protocol handler
-    You can create a custom protocol handler that will return a custom response to request using
-    the specified protocol. In this case, everything going to localimg://* will be handled here
-    */
-    TinyMCE.addProtocolHandler("localimg", new CustomProtocolHandler() {
-      @Override
-      public CustomURLResponse onRequest(CustomURLRequest request) {
-        System.out.println("Requesting " + request.getUrl());
-        // Here we assume that every request is localimg://<name of the image> and we will use <name of the image>
-        // to look for the image in our cache map
-        String imagePath = request.getUrl().substring(11);
-        if (imageCache.containsKey(imagePath)) {
-          // We create a custom response with the content of the image
-          return new CustomURLResponse(Base64.getDecoder().decode(imageCache.get(imagePath)), 200);
-        } else {
-          // If we did not find the image, we return a 404
-          return new CustomURLResponse("".getBytes(), 404);
-        }
-      }
-    });
-    final Config config = Config.embedded().addPlugin("image").putProperty("toolbar", "image")
-      /* Set up an Image Upload Handler
-      You must provide an imageUploadHandler that will take a TinyBlob object and return
-      an Optional<String> of the new path of the stored image if stored successfully or
-      an empty Option if the storing failed
-        */
-      .setImageUploadHandler(new ImageUploadHandler() {
+      /* Set up our custom protocol handler
+      You can create a custom protocol handler that will return a custom response to request using
+      the specified protocol. In this case, everything going to localimg://* will be handled here
+      */
+      TinyMCE.addProtocolHandler("localimg", new CustomProtocolHandler() {
         @Override
-        public Optional<String> processImage(TinyBlob blob) {
-          System.out.println("Processing uploaded image " + blob.getName());
-          // After receiving the image blob we store the name and the base64 value in our map
-          imageCache.put(blob.getName(), blob.getBase64());
-          // And return the path of where the image is stored
-          // We will use custom protocols to provide access to our image at localimg://<name of the image>
-          return Optional.of("localimg://" + blob.getName());
+        public CustomURLResponse onRequest(CustomURLRequest request) {
+          System.out.println("Requesting " + request.getUrl());
+          // Here we assume that every request is localimg://<name of the image> and we will use <name of the image>
+          // to look for the image in our cache map
+          String imagePath = request.getUrl().substring(11);
+          if (imageCache.containsKey(imagePath)) {
+            // We create a custom response with the content of the image
+            return new CustomURLResponse(Base64.getDecoder().decode(imageCache.get(imagePath)), 200);
+          } else {
+            // If we did not find the image, we return a 404
+            return new CustomURLResponse("".getBytes(), 404);
+          }
         }
       });
-    // Create a new editor with the above configuration
-    final TinyMCE editor = TinyMCE.futureEditor(config).get();
-    // Set the editor content
-    editor.setHtml(Utils.welcomeText);
-    // Create a button to get the content of the editor
-    final JButton printToConsole = new JButton("Print to console");
-    printToConsole.addActionListener(e -> System.out.println(editor.getHtml()));
-    // Add the editor and button to the JFrame
-    final JFrame frame = new JFrame();
-    frame.add(editor.component(), BorderLayout.CENTER);
-    frame.add(printToConsole, BorderLayout.SOUTH);
-    frame.pack();
-    frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-    // ensure the editor resources are cleaned up when the window is closed
-    TinyMCE.shutdownOnClose(frame);
-    // display the editor
-    frame.setVisible(true);
+      final Config config = Config.embedded().addPlugin("image")
+        .putProperty("toolbar", "image").putProperty("skin", "tinymce-5")
+        /* Set up an Image Upload Handler
+        You must provide an imageUploadHandler that will take a TinyBlob object and return
+        an Optional<String> of the new path of the stored image if stored successfully or
+        an empty Option if the storing failed
+          */
+        .setImageUploadHandler(new ImageUploadHandler() {
+          @Override
+          public Optional<String> processImage(TinyBlob blob) {
+            System.out.println("Processing uploaded image " + blob.getName());
+            // After receiving the image blob we store the name and the base64 value in our map
+            imageCache.put(blob.getName(), blob.getBase64());
+            // And return the path of where the image is stored
+            // We will use custom protocols to provide access to our image at localimg://<name of the image>
+            return Optional.of("localimg://" + blob.getName());
+          }
+        });
+      // Create a new editor with the above configuration
+      final TinyMCE editor = TinyMCE.futureEditor(config).get();
+      // Set the editor content
+      editor.setHtml(Utils.sampleText);
+      // Create a button to get the content of the editor
+      final JButton printToConsole = new JButton("Print to console");
+      printToConsole.addActionListener(e -> System.out.println(editor.getHtml()));
+      // Add the editor and button to the JFrame
+      final JFrame frame = new JFrame();
+      frame.add(editor.component(), BorderLayout.CENTER);
+      frame.add(printToConsole, BorderLayout.SOUTH);
+      frame.pack();
+      frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+      // ensure the editor resources are cleaned up when the window is closed
+      TinyMCE.shutdownOnClose(frame);
+      // display the editor
+      frame.setVisible(true);
+    } catch (ExecutionException | InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public static void main(final String[] args) {
+    SwingUtilities.invokeLater(ImagesProtocolHandlerExample::createAndShowGUI);
   }
 }

--- a/src/cloud/tiny/tinyinswing/examples/image/protocolhandler/ImagesProtocolHandlerExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/image/protocolhandler/ImagesProtocolHandlerExample.java
@@ -43,7 +43,7 @@ public class ImagesProtocolHandlerExample {
         }
       });
       final Config config = Config.embedded().addPlugin("image")
-        .putProperty("toolbar", "image").putProperty("skin", "tinymce-5")
+        .putProperty("toolbar", "image")
         /* Set up an Image Upload Handler
         You must provide an imageUploadHandler that will take a TinyBlob object and return
         an Optional<String> of the new path of the stored image if stored successfully or

--- a/src/cloud/tiny/tinyinswing/examples/image/savinglocal/ImagesSavedLocallyExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/image/savinglocal/ImagesSavedLocallyExample.java
@@ -15,35 +15,44 @@ public class ImagesSavedLocallyExample {
 
   private ImagesSavedLocallyExample(){}
 
-  public static void main(final String[] args) throws ExecutionException, InterruptedException, IOException {
+  private static void createAndShowGUI(final String contentDir) {
+    try {
+      // Create a new embedded configuration
+      final Path contentPath = Paths.get(contentDir);
+      Files.createDirectories(contentPath);
+      final Config config = Config.embedded()
+          .setContentPath(contentPath)
+          .setImageSaverLocal(contentPath)
+          .addPlugin("image").addPlugin("imagetools")
+          .putProperty("toolbar", "image")
+          .putProperty("skin", "tinymce-5");
+      // Create a new editor with the default configuration
+      final TinyMCE editor = TinyMCE.futureEditor(config).get();
+      // Set the editor content
+      editor.setHtml("<p><img src=\"tiny-logo.png\"></p>");
+      // Create a button to get the content of the editor
+      final JButton printToConsole = new JButton("Print to console");
+      printToConsole.addActionListener(e -> System.out.println(editor.getHtml()));
+      // Add the editor and button to the JFrame
+      final JFrame frame = new JFrame();
+      frame.add(editor.component(), BorderLayout.CENTER);
+      frame.add(printToConsole, BorderLayout.SOUTH);
+      frame.pack();
+      frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+      // ensure the editor resources are cleaned up when the window is closed
+      TinyMCE.shutdownOnClose(frame);
+      // display the editor
+      frame.setVisible(true);
+    } catch (ExecutionException | InterruptedException | IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public static void main(final String[] args) {
     if (args.length != 1) {
       System.err.println("Expected the path to the document");
       return;
     }
-    // Create a new embedded configuration
-    final Path contentPath = Paths.get(args[0]);
-    Files.createDirectories(contentPath);
-    final Config config = Config.embedded()
-        .setContentPath(contentPath)
-        .setImageSaverLocal(contentPath)
-        .addPlugin("image").addPlugin("imagetools")
-        .putProperty("toolbar", "image");
-    // Create a new editor with the default configuration
-    final TinyMCE editor = TinyMCE.futureEditor(config).get();
-    // Set the editor content
-    editor.setHtml("<p><img src=\"tiny-logo.png\"></p>");
-    // Create a button to get the content of the editor
-    final JButton printToConsole = new JButton("Print to console");
-    printToConsole.addActionListener(e -> System.out.println(editor.getHtml()));
-    // Add the editor and button to the JFrame
-    final JFrame frame = new JFrame();
-    frame.add(editor.component(), BorderLayout.CENTER);
-    frame.add(printToConsole, BorderLayout.SOUTH);
-    frame.pack();
-    frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-    // ensure the editor resources are cleaned up when the window is closed
-    TinyMCE.shutdownOnClose(frame);
-    // display the editor
-    frame.setVisible(true);
+    SwingUtilities.invokeLater(() -> { createAndShowGUI(args[0]); } );
   }
 }

--- a/src/cloud/tiny/tinyinswing/examples/image/savinglocal/ImagesSavedLocallyExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/image/savinglocal/ImagesSavedLocallyExample.java
@@ -24,8 +24,7 @@ public class ImagesSavedLocallyExample {
           .setContentPath(contentPath)
           .setImageSaverLocal(contentPath)
           .addPlugin("image").addPlugin("imagetools")
-          .putProperty("toolbar", "image")
-          .putProperty("skin", "tinymce-5");
+          .putProperty("toolbar", "image");
       // Create a new editor with the default configuration
       final TinyMCE editor = TinyMCE.futureEditor(config).get();
       // Set the editor content

--- a/src/cloud/tiny/tinyinswing/examples/multipleeditors/MultipleEditorsExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/multipleeditors/MultipleEditorsExample.java
@@ -14,8 +14,7 @@ public class MultipleEditorsExample {
 
   private static void createAndShowGUI() {
     try {
-      final Config config = Config.embedded().putProperty("menubar", "false")
-          .putProperty("skin", "tinymce-5");
+      final Config config = Config.embedded().putProperty("menubar", "false");
       // create both editors in parallel
       final CompletableFuture<TinyMCE> f1 = TinyMCE.futureEditor(config);
       final CompletableFuture<TinyMCE> f2 = TinyMCE.futureEditor(config);

--- a/src/cloud/tiny/tinyinswing/examples/multipleeditors/MultipleEditorsExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/multipleeditors/MultipleEditorsExample.java
@@ -12,55 +12,64 @@ public class MultipleEditorsExample {
 
   private MultipleEditorsExample() {}
 
-  public static void main(final String[] args) throws ExecutionException, InterruptedException {
-    final Config config = Config.embedded().putProperty("menubar", "false");
-    // create both editors in parallel
-    final CompletableFuture<TinyMCE> f1 = TinyMCE.futureEditor(config);
-    final CompletableFuture<TinyMCE> f2 = TinyMCE.futureEditor(config);
-    final TinyMCE e1 = f1.get();
-    final TinyMCE e2 = f2.get();
-    // create buttons to pass the editor content between the two editors
-    final JButton toTheRight = new JButton(">>");
-    toTheRight.addActionListener(a -> {
-      e2.setHtml(e1.getHtml());
-    });
-    final JButton toTheLeft = new JButton("<<");
-    toTheLeft.addActionListener(a -> {
-      e1.setHtml(e2.getHtml());
-    });
-    // create a frame to put everything in
-    final JFrame frame = new JFrame("Multiple Editors Example");
-    // layout the frame
-    frame.setLayout(new GridBagLayout());
-    GridBagConstraints c = new GridBagConstraints();
-    c.insets = new Insets(5, 5, 5, 5);
-    c.fill = GridBagConstraints.BOTH;
-    c.anchor = GridBagConstraints.CENTER;
-    c.weightx = 1;
-    c.weighty = 2;
-    c.gridwidth = 1;
-    c.gridheight = 2;
-    c.gridy = 0;
-    c.gridx = 0;
-    frame.add(e1.component(), c);
-    c.gridx = 2;
-    frame.add(e2.component(), c);
-    c.fill = GridBagConstraints.NONE;
-    c.weightx = 0;
-    c.weighty = 1;
-    c.gridheight = 1;
-    c.gridx = 1;
-    c.gridy = 0;
-    c.anchor = GridBagConstraints.PAGE_END;
-    frame.add(toTheRight, c);
-    c.gridy = 1;
-    c.anchor = GridBagConstraints.PAGE_START;
-    frame.add(toTheLeft, c);
-    // ensure that resources are cleaned up on frame close
-    frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-    TinyMCE.shutdownOnClose(frame);
-    // size and show the frame
-    frame.pack();
-    frame.setVisible(true);
+  private static void createAndShowGUI() {
+    try {
+      final Config config = Config.embedded().putProperty("menubar", "false")
+          .putProperty("skin", "tinymce-5");
+      // create both editors in parallel
+      final CompletableFuture<TinyMCE> f1 = TinyMCE.futureEditor(config);
+      final CompletableFuture<TinyMCE> f2 = TinyMCE.futureEditor(config);
+      final TinyMCE e1 = f1.get();
+      final TinyMCE e2 = f2.get();
+      // create buttons to pass the editor content between the two editors
+      final JButton toTheRight = new JButton(">>");
+      toTheRight.addActionListener(a -> {
+        e2.setHtml(e1.getHtml());
+      });
+      final JButton toTheLeft = new JButton("<<");
+      toTheLeft.addActionListener(a -> {
+        e1.setHtml(e2.getHtml());
+      });
+      // create a frame to put everything in
+      final JFrame frame = new JFrame("Multiple Editors Example");
+      // layout the frame
+      frame.setLayout(new GridBagLayout());
+      GridBagConstraints c = new GridBagConstraints();
+      c.insets = new Insets(5, 5, 5, 5);
+      c.fill = GridBagConstraints.BOTH;
+      c.anchor = GridBagConstraints.CENTER;
+      c.weightx = 1;
+      c.weighty = 2;
+      c.gridwidth = 1;
+      c.gridheight = 2;
+      c.gridy = 0;
+      c.gridx = 0;
+      frame.add(e1.component(), c);
+      c.gridx = 2;
+      frame.add(e2.component(), c);
+      c.fill = GridBagConstraints.NONE;
+      c.weightx = 0;
+      c.weighty = 1;
+      c.gridheight = 1;
+      c.gridx = 1;
+      c.gridy = 0;
+      c.anchor = GridBagConstraints.PAGE_END;
+      frame.add(toTheRight, c);
+      c.gridy = 1;
+      c.anchor = GridBagConstraints.PAGE_START;
+      frame.add(toTheLeft, c);
+      // ensure that resources are cleaned up on frame close
+      frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+      TinyMCE.shutdownOnClose(frame);
+      // size and show the frame
+      frame.pack();
+      frame.setVisible(true);
+    } catch (ExecutionException | InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public static void main(final String[] args) {
+    SwingUtilities.invokeLater(MultipleEditorsExample::createAndShowGUI);
   }
 }

--- a/src/cloud/tiny/tinyinswing/examples/textrange/TextRangeExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/textrange/TextRangeExample.java
@@ -16,8 +16,7 @@ public class TextRangeExample {
 
   private static void createAndShowGUI() {
     try {
-      final Config config = Config.embedded().putProperty("menubar", "false")
-          .putProperty("skin", "tinymce-5");
+      final Config config = Config.embedded().putProperty("menubar", "false");
       // create both editors in parallel
       final CompletableFuture<TinyMCE> f1 = TinyMCE.futureEditor(config);
       final TinyMCE e1 = f1.get();

--- a/src/cloud/tiny/tinyinswing/examples/textrange/TextRangeExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/textrange/TextRangeExample.java
@@ -3,6 +3,7 @@ package cloud.tiny.tinyinswing.examples.textrange;
 import cloud.tiny.tinymceforswing.TinyMCE;
 import cloud.tiny.tinymceforswing.api.config.Config;
 import cloud.tiny.tinymceforswing.api.editor.TextRange;
+import cloud.tiny.tinyinswing.shared.Utils;
 import java.awt.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -20,6 +21,7 @@ public class TextRangeExample {
       // create both editors in parallel
       final CompletableFuture<TinyMCE> f1 = TinyMCE.futureEditor(config);
       final TinyMCE e1 = f1.get();
+      e1.setHtml(Utils.sampleText);
       final JTextArea e2 = new JTextArea(10, 60);
       // create buttons to pass the editor content between the two editors
       final JButton toTheRight = new JButton(">>");
@@ -53,7 +55,7 @@ public class TextRangeExample {
       c.gridx = 0;
       frame.add(e1.component(), c);
       c.gridx = 2;
-      frame.add(e2, c);
+      frame.add(new JScrollPane(e2), c);
       c.fill = GridBagConstraints.NONE;
       c.weightx = 0;
       c.weighty = 1;

--- a/src/cloud/tiny/tinyinswing/examples/textrange/TextRangeExample.java
+++ b/src/cloud/tiny/tinyinswing/examples/textrange/TextRangeExample.java
@@ -13,61 +13,70 @@ public class TextRangeExample {
 
   private TextRangeExample() {}
 
-  public static void main(final String[] args) throws ExecutionException, InterruptedException {
-    final Config config = Config.embedded().putProperty("menubar", "false");
-    // create both editors in parallel
-    final CompletableFuture<TinyMCE> f1 = TinyMCE.futureEditor(config);
-    final TinyMCE e1 = f1.get();
-    final JTextArea e2 = new JTextArea(10, 60);
-    // create buttons to pass the editor content between the two editors
-    final JButton toTheRight = new JButton(">>");
-    toTheRight.addActionListener(a -> {
-      e2.setText(e1.getText());
-      TextRange r = e1.getTextRange();
-      e2.setSelectionStart(r.start);
-      e2.setSelectionEnd(r.end);
-      e2.requestFocus();
-    });
-    final JButton toTheLeft = new JButton("<<");
-    toTheLeft.addActionListener(a -> {
-      e1.setText(e2.getText());
-      TextRange r = TextRange.create(e2.getSelectionStart(), e2.getSelectionEnd());
-      e1.setTextRange(r);
-      e1.component().requestFocus();
-    });
-    // create a frame to put everything in
-    final JFrame frame = new JFrame("Text Range Example");
-    // layout the frame
-    frame.setLayout(new GridBagLayout());
-    GridBagConstraints c = new GridBagConstraints();
-    c.insets = new Insets(5, 5, 5, 5);
-    c.fill = GridBagConstraints.BOTH;
-    c.anchor = GridBagConstraints.CENTER;
-    c.weightx = 1;
-    c.weighty = 2;
-    c.gridwidth = 1;
-    c.gridheight = 2;
-    c.gridy = 0;
-    c.gridx = 0;
-    frame.add(e1.component(), c);
-    c.gridx = 2;
-    frame.add(e2, c);
-    c.fill = GridBagConstraints.NONE;
-    c.weightx = 0;
-    c.weighty = 1;
-    c.gridheight = 1;
-    c.gridx = 1;
-    c.gridy = 0;
-    c.anchor = GridBagConstraints.PAGE_END;
-    frame.add(toTheRight, c);
-    c.gridy = 1;
-    c.anchor = GridBagConstraints.PAGE_START;
-    frame.add(toTheLeft, c);
-    // ensure that resources are cleaned up on frame close
-    frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-    TinyMCE.shutdownOnClose(frame);
-    // size and show the frame
-    frame.pack();
-    frame.setVisible(true);
+  private static void createAndShowGUI() {
+    try {
+      final Config config = Config.embedded().putProperty("menubar", "false")
+          .putProperty("skin", "tinymce-5");
+      // create both editors in parallel
+      final CompletableFuture<TinyMCE> f1 = TinyMCE.futureEditor(config);
+      final TinyMCE e1 = f1.get();
+      final JTextArea e2 = new JTextArea(10, 60);
+      // create buttons to pass the editor content between the two editors
+      final JButton toTheRight = new JButton(">>");
+      toTheRight.addActionListener(a -> {
+        e2.setText(e1.getText());
+        TextRange r = e1.getTextRange();
+        e2.setSelectionStart(r.start);
+        e2.setSelectionEnd(r.end);
+        e2.requestFocus();
+      });
+      final JButton toTheLeft = new JButton("<<");
+      toTheLeft.addActionListener(a -> {
+        e1.setText(e2.getText());
+        TextRange r = TextRange.create(e2.getSelectionStart(), e2.getSelectionEnd());
+        e1.setTextRange(r);
+        e1.component().requestFocus();
+      });
+      // create a frame to put everything in
+      final JFrame frame = new JFrame("Text Range Example");
+      // layout the frame
+      frame.setLayout(new GridBagLayout());
+      GridBagConstraints c = new GridBagConstraints();
+      c.insets = new Insets(5, 5, 5, 5);
+      c.fill = GridBagConstraints.BOTH;
+      c.anchor = GridBagConstraints.CENTER;
+      c.weightx = 1;
+      c.weighty = 2;
+      c.gridwidth = 1;
+      c.gridheight = 2;
+      c.gridy = 0;
+      c.gridx = 0;
+      frame.add(e1.component(), c);
+      c.gridx = 2;
+      frame.add(e2, c);
+      c.fill = GridBagConstraints.NONE;
+      c.weightx = 0;
+      c.weighty = 1;
+      c.gridheight = 1;
+      c.gridx = 1;
+      c.gridy = 0;
+      c.anchor = GridBagConstraints.PAGE_END;
+      frame.add(toTheRight, c);
+      c.gridy = 1;
+      c.anchor = GridBagConstraints.PAGE_START;
+      frame.add(toTheLeft, c);
+      // ensure that resources are cleaned up on frame close
+      frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+      TinyMCE.shutdownOnClose(frame);
+      // size and show the frame
+      frame.pack();
+      frame.setVisible(true);
+    } catch (ExecutionException | InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public static void main(final String[] args) {
+    SwingUtilities.invokeLater(TextRangeExample::createAndShowGUI);
   }
 }

--- a/src/cloud/tiny/tinyinswing/shared/Utils.java
+++ b/src/cloud/tiny/tinyinswing/shared/Utils.java
@@ -2,69 +2,21 @@ package cloud.tiny.tinyinswing.shared;
 
 public class Utils {
 
-  public final static String welcomeText = "<!DOCTYPE html>\n"+
-      "<html>\n"+
-      "<head>\n"+
-      "</head>\n"+
-      "<body>\n"+
-      "<p style=\"text-align: center;\">&nbsp;</p>\n"+
-      "<p style=\"text-align: center;\"><span style=\"color: #bdc3c7;\">&rarr; This is a full-featured editor demo. Please explore! &larr;</span></p>\n"+
-      "<p style=\"text-align: center;\">&nbsp;</p>\n"+
-      "<h2 style=\"text-align: center; color: #1976d2;\">TinyMCE provides a <span style=\"text-decoration: underline;\">full-featured</span> rich text editing experience, <br />and a featherweight download.</h2>\n"+
-      "<p style=\"text-align: center;\">&nbsp;</p>\n"+
-      "<p style=\"text-align: center;\"><span style=\"font-size: 14pt;\"> <strong> <span style=\"color: #7e8c8d;\">No matter what you're building, TinyMCE has got you covered.</span> </strong> </span></p>\n"+
-      "<table style=\"border-collapse: collapse; width: 70%; margin-left: auto; margin-right: auto; border: 0;\">\n"+
-      "<tbody>\n"+
-      "<tr>\n"+
-      "<td style=\"width: 25%; text-align: center; padding: 7px;\"><span style=\"color: #95a5a6;\">\uD83D\uDEE0 50+ Plugins</span></td>\n"+
-      "<td style=\"width: 25%; text-align: center; padding: 7px;\"><span style=\"color: #95a5a6;\">\uD83D\uDCA1 Premium Support</span></td>\n"+
-      "<td style=\"width: 25%; text-align: center; padding: 7px;\"><span style=\"color: #95a5a6;\">\uD83D\uDD8D Custom Skins</span></td>\n"+
-      "<td style=\"width: 25%; text-align: center; padding: 7px;\"><span style=\"color: #95a5a6;\">⚙ Full API Access</span></td>\n"+
-      "</tr>\n"+
-      "</tbody>\n"+
-      "</table>\n"+
-      "<p style=\"text-align: center;\">&nbsp;</p>\n"+
-      "</body>\n"+
-      "</html>";
-
-  public static final String lorumIpsum = "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>";
-
-  public final static String sampleText = "<p style=\"text-align: center;\"><img title=\"TinyMCE Logo\" src=\"https://www.tiny.cloud/images/glyph-tinymce@2x.png\" alt=\"TinyMCE Logo\" width=\"110\" height=\"97\" /></p>\n" +
-      "<h1 style=\"text-align: center;\">Welcome to the TinyMCE editor demo!</h1>\n" +
-      "<p>Please try out the features provided in this basic example.<br />Note that any <strong>MoxieManager</strong> file and image management functionality in this example is part of our commercial offering &ndash; the demo is to show the integration.</p>\n" +
-      "<h2>Got questions or need help?</h2>\n" +
-      "<ul>\n" +
-      "<li>Our <a href=\"https://www.tiny.cloud/docs/\">documentation</a> is a great resource for learning how to configure TinyMCE.</li>\n" +
-      "<li>Have a specific question? Visit the <a href=\"https://community.tinymce.com/forum/\" target=\"_blank\" rel=\"noopener\">Community Forum</a>.</li>\n" +
-      "<li>We also offer enterprise grade support as part of <a href=\"https://www.tiny.cloud/pricing/\">TinyMCE Enterprise</a>.</li>\n" +
-      "</ul>\n" +
-      "<h2>A simple table to play with</h2>\n" +
-      "<table style=\"text-align: center;\">\n" +
-      "<thead>\n" +
-      "<tr>\n" +
-      "<th>Product</th>\n" +
-      "<th>Cost</th>\n" +
-      "<th>Really?</th>\n" +
-      "</tr>\n" +
-      "</thead>\n" +
-      "<tbody>\n" +
-      "<tr>\n" +
-      "<td>TinyMCE</td>\n" +
-      "<td>Free</td>\n" +
-      "<td>YES!</td>\n" +
-      "</tr>\n" +
-      "<tr>\n" +
-      "<td>Plupload</td>\n" +
-      "<td>Free</td>\n" +
-      "<td>YES!</td>\n" +
-      "</tr>\n" +
-      "</tbody>\n" +
-      "</table>\n" +
-      "<h2>Found a bug?</h2>\n" +
-      "<p>If you think you have found a bug please create an issue on the <a href=\"https://github.com/tinymce/tinymce/issues\">GitHub repo</a> to report it to the developers.</p>\n" +
-      "<h2>Finally ...</h2>\n" +
-      "<p>Don't forget to check out our other product <a href=\"http://www.plupload.com\" target=\"_blank\" rel=\"noopener\">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>\n" +
-      "<p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br />All the best from the TinyMCE team.</p>";
+  public final static String sampleText = "<h1>Welcome to TinyMCE's Java swing integration</h1>\n" +
+  "<p>This is an interactive demo. Please explore!</p>\n" +
+  "<p>The <code>tinymce-swing</code> integration enables the full power of HTML5 content in your Java swing application.</p>\n" +
+  "<ul>\n" +
+  "<li>With no plugins at all you can create headings, apply formats and style text. Lists, tables and images will display perfectly though they won't have GUI's to manipulate them.</li>\n" +
+  "<li>The integration enables a few helpful plugins by default including:\n" +
+  "<ul>\n" +
+  "<li>the very popular <b>powerpaste</b> plugin to enable pasting from Microsoft Word,</li>\n" +
+  "<li>the <b>popup</b> plugin to open all editor dialogs in Java swing's JDialogs,</li>\n" +
+  "<li>the <b>swing-integration</b> plugin to enable some features that were previously only available in EditLive like cursor offsets in text output.</li>" +
+  "</ul>\n" +
+  "</li>\n" +
+  "<li>Enable the <b>lists</b> and <b>advlist</b> plugins to use unordered or ordered varieties, with nesting and multiple styles.</li>\n" +
+  "<li>Enable the <b>table</b> and <b>advtable</b> plugins to use the full power of tables with GUI's to manage sizing, borders and styling.</li>\n" +
+  "</ul>";
 
   public final static String localImage = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAYMAAACCCAMAAACTkVQxAAAAk1BMVEX///8ZddEAbs8AcNAFcdB4pN/6/f/d5/ZmmtwAac4GddHx9fsTc9AAa87l7vjT4vXr9PymyOw7g9Wdv+l7qeHK3fPg7Pm10O9AjNmMr+NNjdijxOsqfNNel9z2+v4AZ82JtOVqoN7W5fbA1vC40e8ngNWTueaCsOO30u9Oktpmnt6Gs+RzqOF0ot5Bh9djltoAYsxOtuvUAAAPK0lEQVR4nO1dC3eqOBAWSPFBUNT62KpU66t6e939/79ufZCZCElIILRa/c6ePbsVCGQyk8nMl0mtZgf1uW/pSU8UxEfP/frpd3hwdELiuIv4p1/jkbGcUsdxyP6n3+OBsQxPInActxFU3VQcMCinH7ys6he6EYyciwgcx5tVbY7mh7cLDkPFVf4ru+ytXfEL3Qa6IRPBUQi7qNrGXlx6BnHriqv8hpdcRh9CBn2KIjgK4a1a7X8hSUM5Mkguo61HkEGfaQFlQqj0q3VlQB9IBluSfC05MCEoLXVZPPUgDf/VTXreffX/hIk0eh/VtfjUgxT8BRtu7ilSsSXVC+GpB9eIF17ypd729P/+pnkZfmQ9qKrNpwyuEM+YCNxN8qdN4iPRaVVCeNoiHgGKYA5/7DNNaC2rafWpBxyiMRiiCffnCdOE1qiSZp96gIje2EjzNlc/dBNNoLQSITz1AFDvsY+k3dRPXYcJYSK8tRyeesDAiSDb0Sx+RElaPBbw1IMEgykbZvRT8POqRYVmygaeenBBZyo1RBesmCa4fdtt68rA/d1x0xVlIpCuApiiUHdruXGQgaeUwXzGUHEs/WfALM1xDSAyRBcsIY5k2RzpyaAWA+w2fxuYQKB02lFcBvbK/bLKedGzRb8bXZaxyQtHDFpMCFubQnjKoDZnNiY/NvqxZkJoWDQITxlsUAQqQ3QBmqO/9oTw8DKAjA3RypUN2UrO3VkTwoPLwN96zCfRTFd+9Jh31LDlIlYuA//iTvn+LdJn/YXLRKCdtm8fErF5Y0tC0PRNCyHujDb7A3lvvod02tstNqPOba0u4hcUgf6b1cdJn3m7Ypn+IIW/IINO+ieeUyf6G3wJ/MZbyLizPUw9j1z8vtMSm3hkelhM2nKFCIRP0kSsekfxHbMiIuDSDN66iBCC1nvzCkwEjhM2U3ifwW3+LrntPcy22v8vueE/jKRE/XVIrohSFwecEtedrWQ9DC/336v5l/XgZs1lbNQAEezMSFxtlm4jh3xXKvum60y/SEEbcJsyZteHT2Ex32iz9uTtEHroiqXQZRMkXRuHpbrsLWhPb3AGY5iOZ6Y8umCXtEZa5nSLwjJQxK4zMlitXXUrNNwJU7NtxqlyzIOTYzCqeiG1+g5FYG75Ika/KEC3+AY9CBpZG5R9Nv0SWeA5KELP8MM+odFQS4WGPRDBvoijD3MJaZmao+r1oP2WowTJg7yDQBWid/h9ZfRdwMxyyCz/6lpt0AO1WRg1BAi+XNYlZq9avQyGqQYo8dwTPJJumLQEudk9dKXZJqQOKFBLxzZ8tGBZVDgE6u8THiSlZpyXowyuwfVWGqSALYrGhHugF4br2Xy0Wq1G8/06DL0rK0W9rNFfMlFRarReWYAMZhp9upyCqEts+ou3TBMkqTcJgnXrGtgjrTTM9aDrH1AEHn3bLvnB7C/nby3PQQhys/EMtr+Y9M4H7JoJNcbkgGVsaFguEfCXaQIxMUf+IIV/YUR00z8N0O3S0wMy+QMOohful9lZNxgsXM5rpW7GHE3gCVMDh3GDTm3+xSNIF9CMCxXsxnJkXFh/wzShVJIZYxXKvVAqPYBucxg1Qeb2nDBcOJwQsloM8wbRp/JE0LCXT8JagQjCrBcbTQkhFP+hBP9N1tlR8co0wSvBedHMJ6v0AGUA3TdV6SZa49Pz0qLfglbpB4dReQ65jmnfBS2YZ39FaWZBBTKo9ZkQQsHTNGGBXwS2iIHkRF8wSHBa7ac+7GNqYtrPiMEXy8+2dz3QAtG1xjI4jpnSnBerepB0RG70JZrhLRnnCN3ThvDmLFZgAsO8lue400zYZeYyqHWZYoWvBSd4C3qQkgFZ5L9K3AD/iLqpJw6a7BdHbwUav8E4mudcinN3U2y/I8eTwhXL4PhQtmutYKbfuh6Qg44Zb69hTvDSMVKwLJq0wgG6Umqh+WwGPYpXMoXG/yiwkXzZiAkhLFbdQlcGunpAp5opQfSh0j2H0dOpVlR/Bp/worwufmUX0lDO5CoC4Cd5hYRggW96JQPB2lfy3iHcknIRhz2YlXUcvg5O4ko1iPegBUq3rQhWTBPSc6G/0IjiWtYDMtZ+7x2MSjdlZyF6Sg4az3mFq5XRugCmIOrZ39PUBbLk1UIueHHdTe4kYVkGrv7nrWA54aaGexvNdv7j2i0waqrRHe1w1qhiW9mSrfz4tOg51eP+zbvXrl9ETdIhqAjpAQzuqZcfz8E13ZuibdjmdFyaVbO9csVMIgG6Rfvyhe5rjsds1y8yiC8c3QkY7utUQhAGFW3lzcqR1uQxhFgiEVJKg8gMImkDGdVLFuttpIOpv8KqHlBqQk8IMMqTsg4xqIj7J+chE3Si5CozPGAURZj/fV33TLCeix4ygG0k54x2HWPIOas3q34R2amaygBm08xCAANAPbVUY+hdhUMGTF0pq3fhZbInKrhi2gdowqmZD4yK5ZHBrM7J2VC0EhBjyMguxolWHQj9BHsmZ1MAT/do9CQXQSZUD5llJWuJWR8y7WLQw5vlBBKtzgeeWXob1mm0lf4J3VNlXswHoyVnU4CJOBpq2TdakgFqHMWkuqvyFc6wqQe0Z8gKgvm0mX5NzYXXgPm31JWpAczvqsC2LRnUhmMvda27yJ0jbc4HxJQrBYnLMGOm0T1V8R44J1ZyBa5CPEVuYd90TdCU51nrh2shuBreuk2/iLwYxg2/2Ptm4zdLiJ4qAlBD0EBH4vSPwCYokxrLSdcEE8USo/3GC8F90Vgw2bRF3j/57V0BQsmCyRx5c3KH5ysvTAE7zY7T/ndRvts7TEG4e51RaVUGpntGu4o70fHvyb4DuUySlFsfK2QSmxvIlIgaMLlobh20OR9ox0wZPuHOeea3Ni6AZe4pqBHZCb91ztOZSON7NqHEmKjNjxRdYHM+MJbBknn3ROBZQrRfZmh88J2EhTz8V65OrPMNpWLP4KYD7a3kP6oHAyYDkbPXhglXQl8ELgFN8wLO+Er7mxJtsYpohiLQ3kPxo3qglAGXHxOuvzCNzNU9w18hY4N0Jrl3OuyYQeaqDcEzNaFZ3K4ecNFTV2RFRhCBEDHycGL0esDso7KiyV8ZoqcakkU5GiIqGhcy3LAeYDxOGIdShSkCIM+cOK1/CK7TxCPYMGYnWSfX15iqM4mc3bAecEGQcXb8IgVmmn3zPdx5LnQDrCJZvMJKrAL2azqUGPXEDetBLQB+tIDhDxtKRSd1sNg9o9f3kcUqjF7bkEEH9jSYkk9vWQ/46Gn6pw5Et11Rpw7PHYLkemCZiuPXFmQAcWvzwoO3rAcYFnUyYVGocSBZe52yl5QjC3RBE0QFchrvoQneszG7AWoBMS3AedN6gN4NSV0QuQozdUZ7Ta7G4wS8I0E+s10fmqCe8dMGkKorUIj2pvUAF9Lp1MQGYrVSQlN7fN0ZI4zfWWe3DFDLFMXYZLhtPeDSxVc2NjrkBpOOU3rq/1EItvkty2kp8d62HnDR0yvKHVJShWEKCbiU2tQm4XTpltOw29aDo1WHdCc/dJGabdTkp4OaYM8cjVoogkL6deN6wLFJuWUAsimmZhnsAWqCjP1ujFVYUgQ3L4MPpImCNwNvo7hP1iJS7oXbB/3VSI5PkRc8oerlnwYs2KJulTLwMW0/h9tg/ZzZUZiLDlUupSIaSjP5oSg2OApLi8CGHlQqg6M3w/oMSEh7L/82Kbj1rCC8bLofbYNBkOLHd926HtR8jJ4mFpyjxhexv1irgtJMpstQBnikY5kT1G5eD3A5xoj1EKagZvRWBiTj0ky60UwGc1h7mxVjS+Hm9QC7JfEnkU3hFVxptTlNmKcbI9KsQWafPtI2yLjMOYK3rweY3L9Q7rA8hmEVOkQbd4Sk6CfBuHeQoZdq7xV5tuXqzd6+HtQ6sLJqnhQeZ8HiBwRFU7BnKUqHKlSXClnhpsZduUMh7kAPargHfMPv3pmWGHzBDjO/hern+AsUgVblMAXuQA9qS64kCLdFp9QRTYFik7oGfNgG57ilj+W4BxkEGD1dDjAfVs4ABHvsReOqgnEDtUCQSjWEBb5p5TKo9ZHUuOPtUinEuFXA/WtmjuIvvHVR/ozxe9CDWpuLd8J/lD5VOv6Cwewa7ZyACrM5uyN0cQ9zMkdyB9j4eK56jEmR04DnM9pgc994/iBBJy0DSgoUms7A33LOje7MijWaqVHdQzluPXZ9QQzR0wQ6RZI04L+gd6QphIirs/HHDon4PvQAyaXsBktpMH+OmqB1CkV7LFvdFcd96EHNvy4ffJ1dLgN/i3E3jeVuewxOgb2T6u5EDzB6enlZi+cYbwzizxy3XVQVsiDuwy86DkA+qJxXONIMG3B4vbG6wHMd8z/G36rAXawPTthyrpHlo1u5GLTy/Aqse0GpzTe4Fz2oDXBWpsTyHksuL684XAWrgFg+yfpu9AA3LOue9GGACWpCupYSoMNpgd3DxO9GD2orZLnYP0asi4Vi1mK3d4BXaFR4M8JdxOzOgFm5SKw5F1xRBeE2UKz+Qh3bVSH/uuSCMOcc8eQyIpBByB5hLINmUlVdZx8puMDZAiM2sOIYi9lOXiKxuhCZQ4n+v40L/lUtUPw5u0xwSOQSHmHqtX8c3hLkr3dgR7hhsTBtrHD7ZoaMyhGrbRuin4ZvcC4gUK0rqE56AceDbF1PuiuOWG0jVninCJhbZFS+0wxL5EESXtCrVoWG6I4wgtnArl94Ba7yHbfnpNvEJdxDHnDMsIYFSpWtcDv7ICTV5Y43qcQbuBd8AunUbpgijTouxJK46ORdox7eIwAYLZX3A7caPnOM+xjGWD+0IcJjJry8ur+lwZdemdc2OBdYjdXeIYBpF1bfER9IyyYzraqQDwHYRmaFSpKHCEtxYcGXwvziXwKfnYZJjc/JLYThLk3j8GSFjx4GHTYcv6suIEfiuojA+KDxXwfYhtn8rlVq1OA1oeT2gt8A2H9gcNhOWcT8KXqFDhr/XcBt4hbZFHmIFrDdR6tW7+/GkDlF3+uh+wk33v16agHyfSsOU6QRn/ebke/whm8ddTyo4rttwsKlhc8h/VWAmnb2uIW68P+EVaSu7w5wBB39iZDZ6KkFR8whWmeH6/+EMSI84qD03qcnimGSV4D/iaoRYArzkZPpP4ouHFLxDWcXPCFCNHWTs+zf7R78/YQ2hn2GiZEa/A90Rz4rK5Gt+wAAAABJRU5ErkJggg==";
 


### PR DESCRIPTION
There is a lot of "noise" in the PR but it was mostly just ensuring that the swing components were all created on the swing thread and that we used correct configs for TinyMCE 6.

Note that I am still working on improving the "advertising copy" that is used as the sample text. Suggestions for things I should mentions and features that I should demo (provided they can be demoed in static content without requiring plugins) are welcome.

Before merging this I intend release an update to the integration that will fix the bug in the image upload. I will probably also set the default rendering mode to on screen and set the default skin to "tinymce-5" as the default skin for TinyMCE 6 is terrible with the java integration. If I do set the default skin to "tinymce-5" I will remove that from these demos.